### PR TITLE
Update CI image used for testing

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -9,7 +9,7 @@ jobs:
     name: Test against ponyc master
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl:latest
     steps:
       - uses: actions/checkout@v1
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl:release
     steps:
       - uses: actions/checkout@v1
       - name: Test


### PR DESCRIPTION
The "-with-ssl" image from shared-docker is being removed and replaced
with images that are more explicit in their naming about the SSL library
(and possibly version) used.