### PR TITLE
Fix HTTP/1.0 connections not closing without keep-alive

### DIFF
--- a/.release-notes/19.md
+++ b/.release-notes/19.md
@@ -1,0 +1,3 @@
+## Fix HTTP/1.0 connections not closing without keep-alive
+
+Due to a logic bug this lib was not closing HTTP/1.0 connections when the request wasnt sending a `Connection` header. This caused tools like [ab](https://httpd.apache.org/docs/2.4/programs/ab.html) to hang, as they expect the connection to close to determine when the request is fully done, unless the `-k` flag is provided.

--- a/examples/httpserver/httpserver.pony
+++ b/examples/httpserver/httpserver.pony
@@ -161,6 +161,13 @@ class BackendHandler is Handler
       .set_status(StatusOK)
       .add_header("Content-Type", "text/plain")
       .add_header("Server", "http_server.pony/0.2.1")
+    // correctly handle HTTP/1.0 keep-alive
+    // TODO: move this handling to ServerConnection or ResponseBuilder
+    match (request.version(), request.header("Connection"))
+    | (HTTP10, "Keep-Alive") =>
+      header_builder = header_builder.add_header("Connection", "Keep-Alive")
+    end
+
     // if request is chunked, we also send the response in chunked Transfer
     // Encoding
     header_builder =

--- a/examples/httpserver/httpserver.pony
+++ b/examples/httpserver/httpserver.pony
@@ -160,6 +160,7 @@ class BackendHandler is Handler
     var header_builder = _response_builder
       .set_status(StatusOK)
       .add_header("Content-Type", "text/plain")
+      .add_header("Server", "http_server.pony/0.2.1")
     // if request is chunked, we also send the response in chunked Transfer
     // Encoding
     header_builder =

--- a/examples/sync_httpserver/main.pony
+++ b/examples/sync_httpserver/main.pony
@@ -95,6 +95,15 @@ actor Main
                               .set_status(StatusOK)
                               .set_transfer_encoding(request.transfer_coding())
                               .add_header("Content-Type", "text/plain")
+                              .add_header("Server", "http_server.pony/0.2.1")
+
+              // correctly handle HTTP/1.0 keep alive
+              // TODO: move this away from user responsibility
+              // into the lib
+              match (request.version(), request.header("Connection"))
+              | (HTTP10, "Keep-Alive") =>
+                header_builder = header_builder.add_header("Connection", "Keep-Alive")
+              end
               // add a Content-Length header if we have no chunked Transfer
               // Encoding
               match request.transfer_coding()

--- a/http_server/_server_connection.pony
+++ b/http_server/_server_connection.pony
@@ -58,6 +58,8 @@ actor _ServerConnection is Session
       _close_after = request_id
     | (HTTP10, let connection_header: String) if connection_header != "Keep-Alive" =>
       _close_after = request_id
+    | (HTTP10, None) =>
+      _close_after = request_id
     end
     _backend(request, request_id)
     if _pending_responses.size() >= _config.max_request_handling_lag then
@@ -173,6 +175,7 @@ actor _ServerConnection is Session
         break
       end
     end
+
     match _close_after
     | let close_after_me: RequestID if RequestIDs.gte(request_id, close_after_me) =>
       // only close after a request that requested it


### PR DESCRIPTION
Fixes #18 

What was happening under the hood is that ab expects the connection to close, after a request and only to stay open when using `-k` (that is sending the `Connection: Keep-Alive` Header). ab is using HTTP/1.0 and our logic of handling it was missing the case of an HTTP/1.0 request without `Connection` header.

Also when using the keep-alive feature of HTTP/1.0 ab expects the server to acknowledge the keep-alive by sending `Connection: Keep-Alive` in the response. I think this is kindof valid behaviour and should happen that way. I updated the examples to work with this assumption, but didn't manage to get it into the library and out of users responsibility.

I honestly only used `curl` and [wrk](https://github.com/wg/wrk) and my browser to interface with this lib yet.