### PR TITLE
Fix bad links in pony source markdown

### DIFF
--- a/http_server/_server_connection.pony
+++ b/http_server/_server_connection.pony
@@ -233,7 +233,7 @@ actor _ServerConnection is Session
   be send_raw(raw: ByteSeqIter, request_id: RequestID, close_session: Bool = false) =>
     """
     If you have your response already in bytes, and don't want to build an expensive
-    [Response](http-Response) object, use this method to send your [ByteSeqIter](builtin-ByteSeqIter).
+    [Response](http_server-Response) object, use this method to send your [ByteSeqIter](builtin-ByteSeqIter).
     This `raw` argument can contain only the response without body,
     in which case you can send the body chunks later on using `send_chunk`,
     or, to further optimize your writes to the network, it might already contain

--- a/http_server/handler.pony
+++ b/http_server/handler.pony
@@ -13,24 +13,24 @@ interface Handler
 
   ### Receiving Requests
 
-  When an [Request](http-Request.md) is received on an [Session](http-Session.md) actor,
-  the corresponding [Handler.apply](http-Handler.md#apply) method is called
-  with the request and a [RequestID](http-RequestID). The [Request](http-Request.md)
+  When an [Request](http_server-Request.md) is received on an [Session](http_server-Session.md) actor,
+  the corresponding [Handler.apply](http_server-Handler.md#apply) method is called
+  with the request and a [RequestID](http_server-RequestID). The [Request](http_server-Request.md)
   contains the information extracted from HTTP Headers and the Request Line, but it does not
-  contain any body data. It is sent to [Handler.apply](http-Handler.md#apply) before the body
+  contain any body data. It is sent to [Handler.apply](http_server-Handler.md#apply) before the body
   is fully received.
 
-  If the request has a body, its raw data is sent to the [Handler.chunk](http-Handler.md#chunk) method
-  together with the [RequestID](http-RequestID.md) of the request it belongs to.
+  If the request has a body, its raw data is sent to the [Handler.chunk](http_server-Handler.md#chunk) method
+  together with the [RequestID](http_server-RequestID.md) of the request it belongs to.
 
-  Once all body data is received, [Handler.finished](http-Handler.md#finished) is called with the
-  [RequestID](http-RequestID.md) of the request it belongs to. Now is the time to act on the full body data,
+  Once all body data is received, [Handler.finished](http_server-Handler.md#finished) is called with the
+  [RequestID](http_server-RequestID.md) of the request it belongs to. Now is the time to act on the full body data,
   if it hasn't been processed yet.
 
-  The [RequestID](http-Requestid.md) must be kept around for sending the response for this request.
+  The [RequestID](http_server-Requestid.md) must be kept around for sending the response for this request.
   This way the session can ensure, all responses are sent in the same order as they have been received,
   which is required for HTTP pipelining. This way processing responses can be passed to other actors and
-  processing can take arbitrary times. The [Session](http-Session.md) will take care of sending
+  processing can take arbitrary times. The [Session](http_server-Session.md) will take care of sending
   the responses in the correct order.
 
   It is guaranteed that the call sequence is always:
@@ -46,19 +46,19 @@ interface Handler
 
   #### Failures and Cancelling
 
-  If a [Session](http-Session.md) experienced faulty requests, the [Handler](http-Handler.md)
-  is notified via [Handler.failed](http-Handler.md#failed).
+  If a [Session](http_server-Session.md) experienced faulty requests, the [Handler](http_server-Handler.md)
+  is notified via [Handler.failed](http_server-Handler.md#failed).
 
-  If the underlying connection to a [Session](http-Session.md) has been closed,
-  the [Handler](http-Handler.md) is notified via [Handler.closed](http-Handler.md#closed).
+  If the underlying connection to a [Session](http_server-Session.md) has been closed,
+  the [Handler](http_server-Handler.md) is notified via [Handler.closed](http_server-Handler.md#closed).
 
   ### Sending Responses
 
-  A handler is instantiated using a [HandlerFactory](http-HandlerFactory.md), which passes an instance of
-  [Session](http-Session.md) to be used in constructing a handler.
+  A handler is instantiated using a [HandlerFactory](http_server-HandlerFactory.md), which passes an instance of
+  [Session](http_server-Session.md) to be used in constructing a handler.
 
   A Session is required to be able to send responses.
-  See the docs for [Session](http-Session.md) for ways to send responses.
+  See the docs for [Session](http_server-Session.md) for ways to send responses.
 
   Example Handler:
 
@@ -163,10 +163,10 @@ interface HandlerFactory
 
   fun apply(session: Session): Handler ref^
     """
-    Called by the [Session](http-Session.md) when it needs a new instance of the
-    application's [Handler](http-Handler.md). It is suggested that the
+    Called by the [Session](http_server-Session.md) when it needs a new instance of the
+    application's [Handler](http_server-Handler.md). It is suggested that the
     `session` value be passed to the constructor for the new
-    [Handler](http-Handler.md), you will need it for sending stuff back.
+    [Handler](http_server-Handler.md), you will need it for sending stuff back.
 
     This part must be implemented, as there might be more paramaters
     that need to be passed for creating a Handler.
@@ -174,7 +174,7 @@ interface HandlerFactory
 
 interface HandlerWithoutContext is Handler
   """
-  Simple [Handler](http-Handler.md) that can be constructed
+  Simple [Handler](http_server-Handler.md) that can be constructed
   with only a Session.
   """
   new create(session: Session)

--- a/http_server/response.pony
+++ b/http_server/response.pony
@@ -20,7 +20,7 @@ primitive Responses // TODO: better naming
   """
   fun builder(version: Version = HTTP11): ResponseBuilder =>
     """
-    Official way to get a reusable [ResponseBuilder](http-ResponseBuilder.md)
+    Official way to get a reusable [ResponseBuilder](http_server-ResponseBuilder.md)
     to build your responses efficiently.
     """
     _FullResponseBuilder._create(version)
@@ -30,17 +30,17 @@ interface ResponseBuilder
   Basic interface for a ResponseBuilder that can be used with chaining method calls.
   It enforces a strict order of build steps by only making the next step available
   as a return to a function required to transition. E.g. You must call `set_status(...)`
-  in order to get back a [ResponseBuilderHeaders](http-ResponseBuilderHeaders.md) to add
+  in order to get back a [ResponseBuilderHeaders](http_server-ResponseBuilderHeaders.md) to add
   headers to the response. You need to call `finish_headers()` in order to
-  be able to add body data with [ResponseBuilderBody](http-ResponseBuilderBody.md).
+  be able to add body data with [ResponseBuilderBody](http_server-ResponseBuilderBody.md).
 
   You can always reset the builder to start out fresh from the beginning.
   Implementations may take advantage of `reset()` by returning itself here,
   allowing for object reuse.
 
-  Use [ResponseBuilderBody.build()](http-ResponseBuilderBody.md#build) to finally build the
+  Use [ResponseBuilderBody.build()](http_server-ResponseBuilderBody.md#build) to finally build the
   response into a [ByteSeqIter](builtin-ByteSeqIter.md),
-  taylored for use with [Session.send_raw()](http-Session.md#send_raw).
+  taylored for use with [Session.send_raw()](http_server-Session.md#send_raw).
 
   Example usage:
 
@@ -69,7 +69,7 @@ interface ResponseBuilderBody
     """
     Add some body data.
 
-    If Transfer-Encoding is set to [Chunked](http-Chunked.md) in [ResponseBuilderHeaders](http-ResponseBuilderHeaders.md)
+    If Transfer-Encoding is set to [Chunked](http_server-Chunked.md) in [ResponseBuilderHeaders](http_server-ResponseBuilderHeaders.md)
     each call to this function will take care of encoding every added array here in Chunked encoding.
     Add an empty array to add the finishing chunk..
     """
@@ -232,11 +232,11 @@ class val BuildableResponse is (Response & ByteSeqIter)
 
   or by using it as a ByteSeqIter.
 
-  This class exists if you want to use the verbose API of [Session](http-Session.md)
+  This class exists if you want to use the verbose API of [Session](http_server-Session.md)
   and brings lots of convenience, like getters and setters for all common properties.
 
-  If you are looking for a more efficient way to build responses, use a [ResponseBuilder](http-ResponseBuilder.md)
-  as it is returned from [Responses.builder()](http-Responses.md#builder), this class is not introspectable
+  If you are looking for a more efficient way to build responses, use a [ResponseBuilder](http_server-ResponseBuilder.md)
+  as it is returned from [Responses.builder()](http_server-Responses.md#builder), this class is not introspectable
   and only allows adding properties the way they are put on the serialized form in the request. E.g. you must first
   set the status and then the headers, not the other way around. But it makes for a more efficient API.
   """

--- a/http_server/session.pony
+++ b/http_server/session.pony
@@ -9,18 +9,18 @@ interface tag Session
   An HTTP Session lives as long as the underlying TCP connection and receives
   request data from it and writes response data to it.
 
-  Receiving data and parsing this data into [Request](http-Request.md)s is happening on
-  the TCPConnection actor. The [Session](http-Session.md) actor is started when a new TCPConnection
+  Receiving data and parsing this data into [Request](http_server-Request.md)s is happening on
+  the TCPConnection actor. The [Session](http_server-Session.md) actor is started when a new TCPConnection
   is accepted, and shut down, when the connection is closed.
 
   ### Receiving a Request
 
   As part of the Request-Response handling internal to this HTTP library,
-  a Session is instantiated that forwards requests to a [Handler](http-Handler.md),
+  a Session is instantiated that forwards requests to a [Handler](http_server-Handler.md),
   to actual application code, which in turn sends Responses back to the Session instance
-  it was instantiated with (See [HandlerFactory](http-HandlerFactory.md).
+  it was instantiated with (See [HandlerFactory](http_server-HandlerFactory.md).
 
-  See [Handler](http-Handler.md) on how requests are received by application code.
+  See [Handler](http_server-Handler.md) on how requests are received by application code.
 
   ### Sending a Response
 
@@ -34,10 +34,10 @@ interface tag Session
     Start receiving a request.
 
     This will be called when all headers of an incoming request have been parsed.
-    [Request](http-Request.md) contains all information extracted from
+    [Request](http_server-Request.md) contains all information extracted from
     these parts.
 
-    The [RequestID](http-RequestID.md) is passed in order for the Session
+    The [RequestID](http_server-RequestID.md) is passed in order for the Session
     implementation to maintain the correct request order in case of HTTP pipelining.
     Response handling can happen asynchronously at arbitrary times, so the RequestID
     helps us to get the responses back into the right order, no matter how they
@@ -184,7 +184,7 @@ interface tag Session
     This API uses the [TCPConnection.writev](net-TCPConnection.md#writev) method to
     optimize putting the given bytes out to the wire.
 
-    To make this optimized path more usable, this library provides the [ResponseBuilder](http-ResponseBuilder.md),
+    To make this optimized path more usable, this library provides the [ResponseBuilder](http_server-ResponseBuilder.md),
     which builds up a response into a [ByteSeqIter](builtin-ByteSeqIter.md), thus taylored towards
     being used with this API.
 


### PR DESCRIPTION
http_server was extracted from the old `http` package and still referred
to it in places in the docs.