### PR TITLE
BuildableResponse: unify constructor and setter for content length

### DIFF
--- a/http_server/response.pony
+++ b/http_server/response.pony
@@ -255,6 +255,7 @@ class val BuildableResponse is (Response & ByteSeqIter)
     _version = version'
     _transfer_coding = transfer_coding'
     _content_length = content_length'
+    set_content_length(content_length')
 
   fun version(): Version => _version
   fun ref set_version(v: Version): BuildableResponse ref =>

--- a/http_server/test/response.pony
+++ b/http_server/test/response.pony
@@ -1,0 +1,16 @@
+use "ponytest"
+use ".."
+
+primitive ResponseTests is TestList
+  fun tag tests(test: PonyTest) =>
+    test(BuildableResponseTest)
+
+class iso BuildableResponseTest is UnitTest
+  fun name(): String => "responses/BuildableResponse"
+
+  fun apply(h: TestHelper) ? =>
+    let without_length = BuildableResponse()
+    h.assert_is[None](None, without_length.header("Content-Length") as None)
+
+    let with_length = BuildableResponse(where content_length' = 42)
+    h.assert_eq[String]("42", with_length.header("Content-Length") as String)

--- a/http_server/test/test.pony
+++ b/http_server/test/test.pony
@@ -12,4 +12,5 @@ actor Main is TestList
     HeaderTests.tests(test)
     ConnectionHandlingTests.tests(test)
     PipeliningTests.tests(test)
+    ResponseTests.tests(test)
 


### PR DESCRIPTION
Previously, setting a content length via the constructor didn't add a
`Content-Length` header, while setting a length via the
`set_content_length` setter did. Now both options result in an added
`Content-Length` header.