### PR TITLE
Update to deal with changes to reference capabilities subtyping rules

### DIFF
--- a/.release-notes/30.md
+++ b/.release-notes/30.md
@@ -1,0 +1,3 @@
+## Forward prepare for coming breaking change in ponyc
+
+This change has no impact on end users, but will future proof against a coming breaking change in the pony compiler. Users of this version of the library won't be impacted by the coming change.

--- a/http_server/request_parser.pony
+++ b/http_server/request_parser.pony
@@ -319,7 +319,7 @@ class HTTP11RequestParser
                   return _headers_exhausted()
                 end
               end
-              (multi_line_value, hend)
+              (consume multi_line_value, hend)
 
             else
               // single line header, simple processing, in best case no


### PR DESCRIPTION
This commit updates the library to work with Steed's model of subtyping, coming
in the next Pony release.

This change is backwards compatible with ponyc 0.40.0