### PR TITLE
Update benchmark to work with Pony 0.47.0

### DIFF
--- a/bench/bench.pony
+++ b/bench/bench.pony
@@ -14,7 +14,7 @@ actor Main is BenchmarkList
     bench(_MultipartFileUploadBenchmark)
     bench(_ChunkedRequestBenchmark)
 
-actor _TestSession is Session
+actor _TestSession is (Session & HTTP11RequestHandler)
   var _c: (AsyncBenchContinue | None) = None
 
   be set_continue(c: AsyncBenchContinue) =>


### PR DESCRIPTION
This was something we forgot to do when 0.47.0 was released. No release notes since it was not visible to users.