### PR TITLE
Update default connection heartbeat length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ tags
 /.coverage/
 /_corral/
 /_repos/
+
+# IDEs
+/.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@ tags
 /.coverage/
 /_corral/
 /_repos/
-
-# IDEs
-/.vscode/

--- a/.release-notes/47.md
+++ b/.release-notes/47.md
@@ -1,0 +1,7 @@
+## Make minimum default heartbeat 1000ms
+
+Default heartbeat value calculation updated to reflect code comment:
+```
+// use a quarter of the actual configured timeout but at minimum 1 second
+```
+(was defaulting to 1ms before)

--- a/.release-notes/47.md
+++ b/.release-notes/47.md
@@ -1,7 +1,5 @@
-## Make minimum default heartbeat 1000ms
+## Updated default connection heartbeat length
 
-Default heartbeat value calculation updated to reflect code comment:
-```
-// use a quarter of the actual configured timeout but at minimum 1 second
-```
-(was defaulting to 1ms before)
+Previously, the default connection heartbeat was incorrectly set to 1ms. We've updated it to the value it was intended to be: 1000ms.
+
+Sending a heartbeat every millisecond was excessive, and this change should improve performance slightly.

--- a/http_server/server_config.pony
+++ b/http_server/server_config.pony
@@ -75,7 +75,7 @@ class val ServerConfig
      | None =>
        // use a quarter of the actual configured timeout
        // but at minimum 1 second
-       ((connection_timeout.u64() * 1000) / 4).max(1)
+       ((connection_timeout.u64() * 1000) / 4).max(1000)
      | let interval: U64 => interval
      end
 


### PR DESCRIPTION
Calculate default timeout_heartbeat_interval with minimum of 1s

This is as specified in the accompanying code comment "use a quarter of the actual configured timeout *but at minimum 1 second*".