### PR TITLE
Add OpenSSL 3 support

### DIFF
--- a/.release-notes/openssl3.md
+++ b/.release-notes/openssl3.md
@@ -1,0 +1,3 @@
+## Add support for OpenSSL 3
+
+We've added support for working with SSL libraries that use the OpenSSL 3 API by upgrading to `ponylang/net_ssl` version 1.3.0.

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
-  ifeq ($(ssl), 1.1.x)
+  ifeq ($(ssl), 3.0.x)
+	  SSL = -Dopenssl_3.0.x
+  else ifeq ($(ssl), 1.1.x)
 	  SSL = -Dopenssl_1.1.x
   else ifeq ($(ssl), 0.9.0)
 	  SSL = -Dopenssl_0.9.0

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/net_ssl.git",
-      "version": "1.2.1"
+      "version": "1.3.0"
     },
     {
       "locator": "github.com/ponylang/valbytes.git",


### PR DESCRIPTION
Adds support for working with the OpenSSL 3 API via an upgrade of the net_ssl dependency to version 1.3.0.