### PR TITLE
Use correct variable when setting content length

### DIFF
--- a/http_server/response.pony
+++ b/http_server/response.pony
@@ -297,7 +297,7 @@ class val BuildableResponse is (Response & ByteSeqIter)
     _content_length = cl
     match cl
     | let clu: USize =>
-      set_header("Content-Length", cl.string())
+      set_header("Content-Length", clu.string())
     // | None =>
     // TODO: drop header
     end


### PR DESCRIPTION
None is stringable so the previous code here would work, but, in theory could eventually lead to "badness". The intent of the code was to match on a USize | None and set the content length to the string version of the USize if a USize.

However, it was setting to the string version of USize | None. Given the match statement, this was fine for now, but, the intent was clouded.

This could lead to a bug in the future if someone changed the code.