### PR TITLE
Implement the correct method in the server_connection

### DIFF
--- a/http_server/_server_connection.pony
+++ b/http_server/_server_connection.pony
@@ -291,6 +291,6 @@ actor _ServerConnection is (Session & HTTP11RequestHandler)
       dispose()
     end
 
-  be upgrade(notify: TCPConnectionNotify iso) =>
+  be upgrade_protocol(notify: TCPConnectionNotify iso) =>
     _conn.set_notify(consume notify)
 


### PR DESCRIPTION
The first implementation used `upgrade`, which was then changed to `upgrade_protocol`, but the change wasn't reflected in the implementation of the session used by the actual http server.