### PR TITLE
Deprecate in favor of ponylang/stallion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,4 @@ Pony package to build server applications for the HTTP protocol.
 
 ## Status
 
-`http_server` is beta quality software that will change frequently. Expect breaking changes. That said, you should feel comfortable using it in your projects.
-
-## Installation
-
-* Install [corral](https://github.com/ponylang/corral):
-* `corral add github.com/ponylang/http_server.git --version 0.6.3`
-* Execute `corral fetch` to fetch your dependencies.
-* Include this package by adding `use "http_server"` to your Pony sources.
-* Execute `corral run -- ponyc` to compile your application
-
-Note: The `ssl` transitive dependency requires a C SSL library to be installed. Please see the [ssl installation instructions](https://github.com/ponylang/ssl#installation) for more information.
-
-## API Documentation
-
-[https://ponylang.github.io/http_server](https://ponylang.github.io/http_server)
+Deprecated. Use [ponylang/stallion](https://github.com/ponylang/stallion) instead.


### PR DESCRIPTION
Development of this package is ceasing in favor of [ponylang/stallion](https://github.com/ponylang/stallion), the new HTTP server for Pony. This updates the README to point users there ahead of archiving the repository.

Scoped to the README only, matching the existing ponylang deprecation-notice convention (`net_ssl`, `json`).